### PR TITLE
Fix auto manual mode

### DIFF
--- a/src/ducks/providerBalancer/providerCalls/reducer.ts
+++ b/src/ducks/providerBalancer/providerCalls/reducer.ts
@@ -60,7 +60,7 @@ const handleProviderCallFlushed = (
   const call = state[payload.providerCall.callId];
 
   if (!call || !call.pending) {
-    throw Error('Pending provider call not found');
+    console.error('Pending provider call not found when flushing');
   }
 
   return {


### PR DESCRIPTION
If you're contributing code, please link to the issue it resolves and follow the
contributor guidelines at https://github.com/MyCryptoHQ/shepherd/wiki/Contributor-Guidelines#contributing-code and fill out the following template:

Closes #53 

### Changes

* Fix race condition by making `watchBalancerHealth` based on an action channel instead of takeEvery. This allows us to buffer actions when a network switch requests is under way.
* Change pending provider check in flushed calls reducer from throwing an error to logging it instead. This is because this can happen inbetween network switches and doesnt impact the state if it does not exist.


