### PR TITLE
Support custom stores, add pending property for network switches

### DIFF
--- a/__test__/apiTests/customStore.spec.ts
+++ b/__test__/apiTests/customStore.spec.ts
@@ -1,0 +1,70 @@
+import { createMockProxyHandler, MockProvider } from '@test/mockNode';
+import {
+  getAPI,
+  makeMockProviderConfig,
+  MockProviderImplem,
+} from '@test/utils';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { composeWithDevTools } from 'remote-redux-devtools';
+
+describe('custom store tests', () => {
+  it('should allow the usage of a user supplied store', async () => {
+    const { shepherd, redux } = getAPI();
+    shepherd.enableLogging();
+
+    const {
+      shepherdMiddlware,
+      rootReducer: shepherdReducer,
+      selectors,
+      providerBalancerSaga,
+    } = redux;
+
+    const composeEnhancers = composeWithDevTools({
+      realtime: true,
+      port: 8000,
+      maxAge: 300,
+    });
+
+    const sagaMiddleware = createSagaMiddleware();
+
+    const rootReducer = combineReducers({ shepherdReducer });
+    const middleware = composeEnhancers(
+      applyMiddleware(sagaMiddleware, shepherdMiddlware),
+    );
+    const store = createStore<any>(rootReducer, middleware);
+    sagaMiddleware.run(providerBalancerSaga);
+
+    const node = await shepherd.init({
+      customProviders: { MockProvider: MockProviderImplem },
+      storeRoot: 'shepherdReducer',
+      store,
+    });
+
+    const providerArgs = [
+      new MockProvider(),
+      createMockProxyHandler({ baseDelay: 500, failureRate: 0 }),
+    ];
+
+    shepherd.useProvider(
+      'MockProvider',
+      'eth1',
+      makeMockProviderConfig({
+        concurrency: 4,
+        network: 'ETH',
+        requestFailureThreshold: 2,
+        timeoutThresholdMs: 3000,
+      }),
+      ...providerArgs,
+    );
+
+    const res = await node.getBalance('0x');
+    const selectedCall = selectors.providerBalancerSelectors.providerCallsSelectors.getProviderCallById(
+      store.getState(),
+      0,
+    );
+    expect(selectedCall.error).toBeFalsy();
+    expect(selectedCall.result).toBeTruthy();
+    expect(res).toBeTruthy();
+  });
+});

--- a/examples/using-your-own-store.ts
+++ b/examples/using-your-own-store.ts
@@ -1,0 +1,71 @@
+import { createMockProxyHandler, MockProvider } from '@test/mockNode';
+import {
+  getAPI,
+  makeMockProviderConfig,
+  MockProviderImplem,
+} from '@test/utils';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { composeWithDevTools } from 'remote-redux-devtools';
+
+describe('custom store tests', () => {
+  it('should allow the usage of a user supplied store', async () => {
+    const { shepherd, redux } = getAPI();
+    shepherd.enableLogging();
+
+    const {
+      shepherdMiddlware,
+      rootReducer: shepherdReducer,
+      selectors,
+      providerBalancerSaga,
+    } = redux;
+
+    const composeEnhancers = composeWithDevTools({
+      realtime: true,
+      port: 8000,
+      maxAge: 300,
+    });
+
+    const sagaMiddleware = createSagaMiddleware();
+
+    const rootReducer = combineReducers({ shepherdReducer });
+    // make sure to include the shepherdMiddlware last
+    const middleware = composeEnhancers(
+      applyMiddleware(sagaMiddleware, shepherdMiddlware),
+    );
+    const store = createStore<any>(rootReducer, middleware);
+    sagaMiddleware.run(providerBalancerSaga);
+
+    const node = await shepherd.init({
+      customProviders: { MockProvider: MockProviderImplem },
+      storeRoot: 'shepherdReducer',
+      store,
+    });
+
+    const providerArgs = [
+      new MockProvider(),
+      createMockProxyHandler({ baseDelay: 500, failureRate: 0 }),
+    ];
+
+    shepherd.useProvider(
+      'MockProvider',
+      'eth1',
+      makeMockProviderConfig({
+        concurrency: 4,
+        network: 'ETH',
+        requestFailureThreshold: 2,
+        timeoutThresholdMs: 3000,
+      }),
+      ...providerArgs,
+    );
+
+    const res = await node.getBalance('0x');
+    const selectedCall = selectors.providerBalancerSelectors.providerCallsSelectors.getProviderCallById(
+      store.getState(),
+      0,
+    );
+    expect(selectedCall.error).toBeFalsy();
+    expect(selectedCall.result).toBeTruthy();
+    expect(res).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mycrypto-shepherd",
   "version": "1.0.3",
-  "description": "Ensure high-availability for your JSON-RPC calls while improving user-experience. Shepherd automatically cancels calls that are taking too long to respond and executes them against fresh provider infrastructure. Shepherd is incredibly configurable — you can set filters on provider infrastructure to ensure that sensitive JSON-RPC calls are contained, dynamically bias against poorly performing provider infrastructure, and more!",
+  "description":
+    "Ensure high-availability for your JSON-RPC calls while improving user-experience. Shepherd automatically cancels calls that are taking too long to respond and executes them against fresh provider infrastructure. Shepherd is incredibly configurable — you can set filters on provider infrastructure to ensure that sensitive JSON-RPC calls are contained, dynamically bias against poorly performing provider infrastructure, and more!",
   "main": "dist/shepherd.umd.js",
   "module": "dist/shepherd.es6.js",
   "typings": "dist/lib",
@@ -13,17 +14,21 @@
     "test:prod": "npm run test -- --coverage --no-cache",
     "test:prepublish": "npm run lint && npm run test -- --silent --no-cache",
     "tsc": "tsc --noEmit -p ./tsconfig.json",
-    "format": "find ./src/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
+    "format":
+      "find ./src/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
     "remotedev": "remotedev --hostname=localhost --port=8000",
     "lint": "tslint --project .",
     "lint:fix": "tslint --project . --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc -p ./tsconfig-build.json --module commonjs && rollup -c rollup.config.ts && npm run gulp",
-    "prepublishOnly": "rimraf node_modules && npm i && npm run tsc && npm run test:prepublish && npm run build",
+    "build":
+      "tsc -p ./tsconfig-build.json --module commonjs && rollup -c rollup.config.ts && npm run gulp",
+    "prepublishOnly":
+      "rimraf node_modules && npm i && npm run tsc && npm run test:prepublish && npm run build",
     "precommit": "lint-staged",
     "prepush": "npm run lint && npm run tsc",
     "report-coverage": " cat ./coverage/lcov.info | coveralls",
-    "docs": "typedoc --out ./docs ./src --exclude '**/*.spec*' --externalPattern '*node_modules*' --excludeExternals  --includeDeclarations --tsconfig ./tsconfig-build.json  --mode file  --theme minimal"
+    "docs":
+      "typedoc --out ./docs ./src --exclude '**/*.spec*' --externalPattern '*node_modules*' --excludeExternals  --includeDeclarations --tsconfig ./tsconfig-build.json  --mode file  --theme minimal"
   },
   "lint-staged": {
     "{src,__test__,examples}/**/*.ts": [
@@ -41,9 +46,7 @@
   "bugs": {
     "url": "https://github.com/MyCryptoHQ/shepherd/issues"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "homepage": "https://github.com/MyCryptoHQ/shepherd#readme",
   "devDependencies": {
     "coveralls": "^3.0.0",
@@ -79,13 +82,7 @@
     "url-search-params": "^0.10.0"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "json",
-      "ts",
-      "tsx"
-    ],
+    "moduleFileExtensions": ["js", "jsx", "json", "ts", "tsx"],
     "transform": {
       "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
@@ -94,10 +91,7 @@
       "@test/(.*)": "<rootDir>/__test__/$1"
     },
     "testRegex": "((\\.|/)(spec))\\.ts$",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dist/"
-    ],
+    "testPathIgnorePatterns": ["/node_modules/", "/dist/"],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "src/providers/etherscan",
@@ -107,7 +101,6 @@
       "src/providers/web3",
       "src/validators",
       "mockNode.ts"
-    ],
-    "collectCoverage": true
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Shepherd is built to have high configurability for users.
 `npm i mycrypto-shepherd`
 
 # Examples
+
 [Find examples here on how to get started with Shepherd](./examples)
 
 # Shepherd API
@@ -117,13 +118,15 @@ Enables logging for the library
 
 # IProviderConfig
 
-| Name                    | Type     | Description                                                                                                                                                                                                                                                                                                              |
-| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| concurrency             | `string` | The maximum number of concurrent calls to make to the provider instance using this config. This number determines how many workers to spawn to process incoming rpc requests                                                                                                                                             |
-| requestFailureThreshold | `string` | The threshold of failed calls before deeming a provider to be offline (which means it will no longer have rpc calls routed to it), which will then be polled until it responds. If it responds, it will be changed to an online state and continue to have applicable calls as outlined in supportedMethods routed to it |
-| timeoutThresholdMs      | `string` | How long to wait on an rpc call (also applies to the initial ping to determine if a provider is online) before determining that it has timed out                                                                                                                                                                         |
-| supportedMethods        | `string` | All supported rpc methods by this provider config, disable a method for a config by setting it to false, this will prevent any rpc calls set to false to be routed to the provider instance using this config                                                                                                            |
-| network                 | `string` | The associated network name of this provider config to be used by the balancer when switching networks                                                                                                                                                                                                                   |
+| Name                    | Type         | Description                                                                                                                                                                                                                                                                                                              |
+| ----------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| concurrency             | `string`     | The maximum number of concurrent calls to make to the provider instance using this config. This number determines how many workers to spawn to process incoming rpc requests                                                                                                                                             |
+| requestFailureThreshold | `string`     | The threshold of failed calls before deeming a provider to be offline (which means it will no longer have rpc calls routed to it), which will then be polled until it responds. If it responds, it will be changed to an online state and continue to have applicable calls as outlined in supportedMethods routed to it |
+| timeoutThresholdMs      | `string`     | How long to wait on an rpc call (also applies to the initial ping to determine if a provider is online) before determining that it has timed out                                                                                                                                                                         |
+| supportedMethods        | `string`     | All supported rpc methods by this provider config, disable a method for a config by setting it to false, this will prevent any rpc calls set to false to be routed to the provider instance using this config                                                                                                            |
+| network                 | `string`     | The associated network name of this provider config to be used by the balancer when switching networks                                                                                                                                                                                                                   |
+| storeRoot               | `string`     | The root the shepherd rootReducer when using a custom store. E.g If the top level is { foo, shepherdReducer } then `storeRoot` would be `shepherdReducer`. Note that this setting only supports one level of nesting                                                                                                     |
+| store                   | `Store<any>` | The custom store to use if you want to use your own, make sure to supply the setting above too or else it will not work.                                                                                                                                                                                                 |
 
 # FAQ
 

--- a/src/ducks/index.ts
+++ b/src/ducks/index.ts
@@ -1,16 +1,17 @@
 import { filterMiddlware } from '@src/ducks/middleware';
-import { providerBalancer } from '@src/ducks/providerBalancer';
-import { providerConfigs } from '@src/ducks/providerConfigs';
-import { RootState } from '@src/types';
 import {
-  applyMiddleware,
-  combineReducers,
-  createStore,
-  Middleware,
-} from 'redux';
+  providerBalancer,
+  providerBalancerSelectors,
+} from '@src/ducks/providerBalancer';
+import { providerConfigs } from '@src/ducks/providerConfigs';
+import * as providerConfigsSelectors from '@src/ducks/providerConfigs/selectors';
+import { storeManager } from '@src/ducks/store';
+import { RootState } from '@src/types';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { composeWithDevTools } from 'remote-redux-devtools';
 import { providerBalancer as providerBalancerSaga } from '../saga';
+import * as rootSelectors from './selectors';
 
 const sagaMiddleware = createSagaMiddleware();
 const composeEnhancers = composeWithDevTools({
@@ -26,15 +27,27 @@ const rootReducer = combineReducers<RootState>({
 
 const middleware =
   process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
-    ? composeEnhancers(
-        applyMiddleware(sagaMiddleware, filterMiddlware as Middleware),
-      )
-    : applyMiddleware(sagaMiddleware, filterMiddlware as Middleware);
+    ? composeEnhancers(applyMiddleware(sagaMiddleware, filterMiddlware))
+    : applyMiddleware(sagaMiddleware, filterMiddlware);
 
 const store = createStore<RootState>(rootReducer, middleware);
+storeManager.setStore(store);
 
 const INITIAL_ROOT_STATE = rootReducer(undefined as any, {} as any);
 
 sagaMiddleware.run(providerBalancerSaga);
 
-export { providerBalancerSaga, rootReducer, store, INITIAL_ROOT_STATE };
+const selectors = {
+  rootSelectors,
+  providerBalancerSelectors,
+  providerConfigsSelectors,
+};
+
+export {
+  filterMiddlware as shepherdMiddlware,
+  providerBalancerSaga,
+  rootReducer,
+  store,
+  INITIAL_ROOT_STATE,
+  selectors,
+};

--- a/src/ducks/middleware.ts
+++ b/src/ducks/middleware.ts
@@ -1,9 +1,10 @@
 import { AllActions } from '@src/ducks/types';
-import { Dispatch } from 'redux';
+import { Dispatch, Middleware } from 'redux';
 
 import { SUBSCRIBE } from '@src/ducks/subscribe';
 // this should be the last middleware, immediately before the store
 // if it's an subscription action then do not dispatch it to the store
-export const filterMiddlware = () => (next: Dispatch<AllActions>) => (
-  action: AllActions,
-) => (action.type === SUBSCRIBE.ACTION ? undefined : next(action));
+export const filterMiddlware: Middleware = () => (
+  next: Dispatch<AllActions>,
+) => (action: AllActions): any =>
+  action.type === SUBSCRIBE.ACTION ? undefined : next(action);

--- a/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
+++ b/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
@@ -24,12 +24,17 @@ describe('Balancer config tests', () => {
       ).toEqual(3);
     });
 
+    it('should select the network switching pending as false', () => {
+      expect(selectors.isSwitchingNetworks(INITIAL_ROOT_STATE)).toEqual(false);
+    });
+
     it('should select the entire inital state', () => {
       expect(selectors.getBalancerConfig(INITIAL_ROOT_STATE)).toEqual({
         manual: false,
         offline: true,
         network: 'ETH',
         providerCallRetryThreshold: 3,
+        networkSwitchPending: false,
       });
     });
   });
@@ -56,7 +61,6 @@ describe('Balancer config tests', () => {
     it('should set the balancer to online', () => {
       const action = actions.setOnline();
       const selector = selectors.isOffline;
-
       expect(selector(rootReducer(undefined as any, action))).toEqual(false);
     });
     it('should set the balancer to offline', () => {
@@ -79,14 +83,23 @@ describe('Balancer config tests', () => {
       expect(selector(state)).toEqual(false);
     });
 
-    it('should set the network after a successful network switch', () => {
+    it('should set the network switch is pending flag to true', () => {
+      const action = actions.balancerNetworkSwitchRequested({ network: 'ETH' });
+      const selector = selectors.isSwitchingNetworks;
+
+      expect(selector(rootReducer(undefined as any, action))).toEqual(true);
+    });
+
+    it('should set the network after a successful network switch, and set isSwitchingNetworks to false', () => {
       const action = actions.balancerNetworkSwitchSucceeded({
         network: 'ETC',
         providerStats: {},
         workers: {},
       });
       const selector = selectors.getNetwork;
+      const selector2 = selectors.isSwitchingNetworks;
       expect(selector(rootReducer(undefined as any, action))).toEqual('ETC');
+      expect(selector2(rootReducer(undefined as any, action))).toEqual(false);
     });
 
     it('should handle callExceedsBalancerRetryThreshold selector', () => {

--- a/src/ducks/providerBalancer/balancerConfig/reducer.ts
+++ b/src/ducks/providerBalancer/balancerConfig/reducer.ts
@@ -12,6 +12,7 @@ const INITIAL_STATE: IBalancerConfigState = {
   offline: true,
   network: 'ETH',
   providerCallRetryThreshold: 3,
+  networkSwitchPending: false,
 };
 
 const handleBalancerAuto: Reducer<IBalancerConfigState> = (
@@ -46,7 +47,13 @@ export const balancerConfigReducer: Reducer<IBalancerConfigState> = (
     case BALANCER.ONLINE:
       return { ...state, offline: false };
     case BALANCER.NETWORK_SWITCH_SUCCEEDED:
-      return { ...state, network: action.payload.network };
+      return {
+        ...state,
+        network: action.payload.network,
+        networkSwitchPending: false,
+      };
+    case BALANCER.NETWORK_SWTICH_REQUESTED:
+      return { ...state, networkSwitchPending: true };
     case BALANCER.SET_PROVIDER_CALL_RETRY_THRESHOLD:
       return {
         ...state,

--- a/src/ducks/providerBalancer/balancerConfig/selectors.ts
+++ b/src/ducks/providerBalancer/balancerConfig/selectors.ts
@@ -16,6 +16,9 @@ export const getNetwork = (state: RootState) =>
 export const getProviderCallRetryThreshold = (state: RootState) =>
   getBalancerConfig(state).providerCallRetryThreshold;
 
+export const isSwitchingNetworks = (state: RootState) =>
+  getBalancerConfig(state).networkSwitchPending;
+
 export const callMeetsBalancerRetryThreshold = (
   state: RootState,
   { payload: { providerCall } }: IProviderCallTimeout,

--- a/src/ducks/providerBalancer/balancerConfig/types.ts
+++ b/src/ducks/providerBalancer/balancerConfig/types.ts
@@ -26,6 +26,7 @@ export interface IBalancerConfigState {
   manual: false | string;
   offline: boolean;
   providerCallRetryThreshold: number;
+  networkSwitchPending: boolean;
 }
 
 export interface IBalancerInit {

--- a/src/ducks/providerBalancer/index.ts
+++ b/src/ducks/providerBalancer/index.ts
@@ -1,14 +1,29 @@
 import { combineReducers } from 'redux';
 import { balancerConfigReducer } from './balancerConfig';
-import { providerCallsReducer } from './providerCalls';
-import { providerStatsReducer } from './providerStats';
-import { IProviderBalancerState } from './types';
-import { workerReducer } from './workers';
+import * as balancerConfigSelectors from './balancerConfig/selectors';
 
+import { providerCallsReducer } from './providerCalls';
+import * as providerCallsSelectors from './providerCalls/selectors';
+
+import { providerStatsReducer } from './providerStats';
+import * as providerStatsSelectors from './providerStats/selectors';
+
+import { workerReducer } from './workers';
+import * as workersSelectors from './workers/selectors';
+
+import { IProviderBalancerState } from './types';
 export * from './types';
+
 export const providerBalancer = combineReducers<IProviderBalancerState>({
   providerStats: providerStatsReducer,
   workers: workerReducer,
   balancerConfig: balancerConfigReducer,
   providerCalls: providerCallsReducer,
 });
+
+export const providerBalancerSelectors = {
+  balancerConfigSelectors,
+  providerCallsSelectors,
+  providerStatsSelectors,
+  workersSelectors,
+};

--- a/src/ducks/providerBalancer/providerBalancer.spec.ts
+++ b/src/ducks/providerBalancer/providerBalancer.spec.ts
@@ -9,6 +9,7 @@ describe('Provider balancer tests', () => {
         network: 'ETH',
         offline: true,
         providerCallRetryThreshold: 3,
+        networkSwitchPending: false,
       },
       providerCalls: {},
       providerStats: {},

--- a/src/ducks/providerBalancer/selectors.ts
+++ b/src/ducks/providerBalancer/selectors.ts
@@ -1,3 +1,5 @@
+import { getRootState } from '@src/ducks/rootState';
 import { RootState } from '@src/types';
 
-export const getProviderBalancer = (state: RootState) => state.providerBalancer;
+export const getProviderBalancer = (state: RootState) =>
+  getRootState(state).providerBalancer;

--- a/src/ducks/providerConfigs/selectors.ts
+++ b/src/ducks/providerConfigs/selectors.ts
@@ -1,8 +1,10 @@
+import { getRootState } from '@src/ducks/rootState';
 import { providerStorage } from '@src/providers/providerStorage';
 import { AllProviderMethods, RootState } from '@src/types';
 import { IProviderConfigState } from './types';
 
-export const getProviderConfigs = (state: RootState) => state.providerConfigs;
+export const getProviderConfigs = (state: RootState) =>
+  getRootState(state).providerConfigs;
 
 export const getProviderConfigById = (
   state: RootState,

--- a/src/ducks/rootState.ts
+++ b/src/ducks/rootState.ts
@@ -1,0 +1,7 @@
+import { storeManager } from '@src/ducks/store';
+import { RootState } from '@src/types';
+
+export const getRootState = (s: any): RootState => {
+  const customRoot = storeManager.getRoot();
+  return customRoot ? s[customRoot] : s;
+};

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -1,0 +1,29 @@
+import { logger } from '@src/utils/logging';
+import { Store } from 'redux';
+
+class StoreManager {
+  private store: Store<any> | undefined;
+  private root: string | undefined;
+
+  public setRoot(r: string) {
+    logger.log(`Setting root to: ${r}`);
+    this.root = r;
+  }
+
+  public getRoot() {
+    return this.root;
+  }
+
+  public setStore(s: Store<any>) {
+    this.store = s;
+  }
+
+  public getStore() {
+    if (!this.store) {
+      throw Error('no store');
+    }
+    return this.store;
+  }
+}
+
+export const storeManager = new StoreManager();

--- a/src/providers/providerManager.ts
+++ b/src/providers/providerManager.ts
@@ -1,5 +1,5 @@
-import { store } from '@src/ducks';
 import { addProviderConfig, IProviderConfig } from '@src/ducks/providerConfigs';
+import { storeManager } from '@src/ducks/store';
 import { IProviderContructor } from '@src/types';
 import { providerStorage } from './providerStorage';
 
@@ -20,6 +20,6 @@ export function useProvider(
   const provider = new Provider(...args);
   providerStorage.setInstance(instanceName, provider);
   const action = addProviderConfig({ config, id: instanceName });
-  store.dispatch(action);
+  storeManager.getStore().dispatch(action);
   return config;
 }

--- a/src/providers/providerProxy.ts
+++ b/src/providers/providerProxy.ts
@@ -1,4 +1,3 @@
-import { store } from '@src/ducks';
 import { getManualMode } from '@src/ducks/providerBalancer/balancerConfig/selectors';
 import {
   IProviderCall,
@@ -8,6 +7,7 @@ import {
   PROVIDER_CALL,
   providerCallRequested,
 } from '@src/ducks/providerBalancer/providerCalls';
+import { storeManager } from '@src/ducks/store';
 import { subscribeToAction } from '@src/ducks/subscribe';
 import { triggerOnMatchingCallId } from '@src/ducks/subscribe/utils';
 import { AllProviderMethods, IProvider, Reject, Resolve } from '@src/types';
@@ -43,7 +43,7 @@ const makeProviderCall = (
   rpcMethod: AllProviderMethods,
   rpcArgs: string[],
 ): IProviderCall => {
-  const isManual = getManualMode(store.getState());
+  const isManual = getManualMode(storeManager.getStore().getState());
 
   const providerCall: IProviderCall = {
     callId: generateCallId(),
@@ -60,13 +60,13 @@ const makeProviderCall = (
 const dispatchRequest = (providerCall: IProviderCall) => {
   // make the request to the load balancer
   const networkReq = providerCallRequested(providerCall);
-  store.dispatch(networkReq);
+  storeManager.getStore().dispatch(networkReq);
   return networkReq.payload.callId;
 };
 
 const waitForResponse = (callId: number) =>
   new Promise((resolve, reject) =>
-    store.dispatch(
+    storeManager.getStore().dispatch(
       subscribeToAction({
         trigger: triggerOnMatchingCallId(callId, false),
         callback: respondToCallee(resolve, reject),

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1,13 +1,16 @@
-import { StrIdx, IProviderContructor, IProvider } from '@src/types';
 import {
-  balancerInit,
   BalancerConfigInitConfig,
+  balancerInit,
   balancerNetworkSwitchRequested,
 } from '@src/ducks/providerBalancer/balancerConfig';
 import { IProviderConfig } from '@src/ducks/providerConfigs';
+import { IProvider, IProviderContructor, StrIdx } from '@src/types';
+import { Store } from 'redux';
 
 export interface IInitConfig extends BalancerConfigInitConfig {
   customProviders?: StrIdx<IProviderContructor>;
+  storeRoot?: string;
+  store?: Store<any>;
 }
 
 export interface IShepherd {


### PR DESCRIPTION
- Supports custom stores, allowing the lib consumer to use shepherds rootReducer + rootSaga + middleware into their own redux stack. 
- Also adds a pending property for network switches. 
- And exposes shepherds selectors to the api.