### PR TITLE
Buffer network switches

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -59,9 +59,14 @@ class Shepherd implements IShepherd {
       config.providerCallRetryThreshold = 3;
     }
     const node = createProviderProxy();
-    const promise = waitForNetworkSwitch(storeManager.getStore().dispatch);
+    const initAction = balancerInit(config);
 
-    storeManager.getStore().dispatch(balancerInit(config));
+    const promise = waitForNetworkSwitch(
+      storeManager.getStore().dispatch,
+      initAction.meta.id,
+    );
+
+    storeManager.getStore().dispatch(initAction);
     await promise;
     return node;
   }
@@ -147,8 +152,12 @@ class Shepherd implements IShepherd {
     if (getManualMode(storeManager.getStore().getState())) {
       throw Error(`Can't switch networks when in manual mode!`);
     }
-    const promise = waitForNetworkSwitch(storeManager.getStore().dispatch);
     const action = balancerNetworkSwitchRequested({ network });
+
+    const promise = waitForNetworkSwitch(
+      storeManager.getStore().dispatch,
+      action.meta.id,
+    );
     storeManager.getStore().dispatch(action);
     await promise;
   }

--- a/src/ducks/ducks.spec.ts
+++ b/src/ducks/ducks.spec.ts
@@ -102,11 +102,14 @@ describe('Ducks tests', () => {
       storage = undefined;
       storage = rootReducer(
         storage,
-        balancerConfigActions.balancerNetworkSwitchSucceeded({
-          network: 'ETC',
-          providerStats: {},
-          workers: {},
-        }),
+        balancerConfigActions.balancerNetworkSwitchSucceeded(
+          {
+            network: 'ETC',
+            providerStats: {},
+            workers: {},
+          },
+          0,
+        ),
       );
       storage = addAllProviderConfigs(storage, configs);
       storage = addAllProviderStats(storage, Object.keys(configs));

--- a/src/ducks/providerBalancer/balancerConfig/actions.ts
+++ b/src/ducks/providerBalancer/balancerConfig/actions.ts
@@ -1,3 +1,4 @@
+import { idGeneratorFactory } from '@src/utils/idGenerator';
 import {
   BALANCER,
   IBalancerAuto,
@@ -18,18 +19,22 @@ export const balancerFlush = (): IBalancerFlush => ({
   type: BALANCER.FLUSH,
 });
 
+const networkIdGenerator = idGeneratorFactory();
 export const balancerNetworkSwitchRequested = (
   payload: IBalancerNetworkSwitchRequested['payload'],
 ): IBalancerNetworkSwitchRequested => ({
   payload,
   type: BALANCER.NETWORK_SWTICH_REQUESTED,
+  meta: { id: networkIdGenerator() },
 });
 
 export const balancerNetworkSwitchSucceeded = (
   payload: IBalancerNetworkSwitchSucceeded['payload'],
+  id: number,
 ): IBalancerNetworkSwitchSucceeded => ({
   type: BALANCER.NETWORK_SWITCH_SUCCEEDED,
   payload,
+  meta: { id },
 });
 
 export const balancerSetProviderCallRetryThreshold = (
@@ -41,7 +46,11 @@ export const balancerSetProviderCallRetryThreshold = (
 
 export const balancerInit = (
   payload: IBalancerInit['payload'],
-): IBalancerInit => ({ type: BALANCER.INIT, payload });
+): IBalancerInit => ({
+  type: BALANCER.INIT,
+  payload,
+  meta: { id: networkIdGenerator() },
+});
 
 export const setOffline = (): IBalancerOffline => ({
   type: BALANCER.OFFLINE,

--- a/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
+++ b/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
@@ -91,11 +91,14 @@ describe('Balancer config tests', () => {
     });
 
     it('should set the network after a successful network switch, and set isSwitchingNetworks to false', () => {
-      const action = actions.balancerNetworkSwitchSucceeded({
-        network: 'ETC',
-        providerStats: {},
-        workers: {},
-      });
+      const action = actions.balancerNetworkSwitchSucceeded(
+        {
+          network: 'ETC',
+          providerStats: {},
+          workers: {},
+        },
+        0,
+      );
       const selector = selectors.getNetwork;
       const selector2 = selectors.isSwitchingNetworks;
       expect(selector(rootReducer(undefined as any, action))).toEqual('ETC');

--- a/src/ducks/providerBalancer/balancerConfig/types.ts
+++ b/src/ducks/providerBalancer/balancerConfig/types.ts
@@ -32,6 +32,7 @@ export interface IBalancerConfigState {
 export interface IBalancerInit {
   type: BALANCER.INIT;
   payload: BalancerConfigInitConfig;
+  meta: { id: number };
 }
 
 export interface IBalancerFlush {
@@ -45,6 +46,7 @@ export interface IBalancerQueueTimeout {
 export interface IBalancerNetworkSwitchRequested {
   type: BALANCER.NETWORK_SWTICH_REQUESTED;
   payload: { network: string };
+  meta: { id: number };
 }
 
 export interface IBalancerNetworkSwitchSucceeded {
@@ -54,6 +56,7 @@ export interface IBalancerNetworkSwitchSucceeded {
     workers: IProviderBalancerState['workers'];
     network: string;
   };
+  meta: { id: number };
 }
 
 export interface IBalancerSetProviderCallRetryThreshold {

--- a/src/ducks/providerBalancer/providerStats/providerStats.spec.ts
+++ b/src/ducks/providerBalancer/providerStats/providerStats.spec.ts
@@ -217,11 +217,14 @@ describe('Provider stats tests', () => {
         mock1: { ...mockProviderStats, workers: [] },
         mock2: { ...mockProviderStats, workers: [] },
       };
-      const action = balancerActions.balancerNetworkSwitchSucceeded({
-        network: 'ETC',
-        providerStats: mockProviderStatsState,
-        workers: {},
-      });
+      const action = balancerActions.balancerNetworkSwitchSucceeded(
+        {
+          network: 'ETC',
+          providerStats: mockProviderStatsState,
+          workers: {},
+        },
+        0,
+      );
       states.networkSwitchSucceeded = providerStatsReducer(
         states.providerAdded,
         action,
@@ -243,6 +246,7 @@ describe('Provider stats tests', () => {
           providerStats: belowZeroMockProviderStatsState,
           workers: {},
         },
+        0,
       );
       expect(() =>
         providerStatsReducer(undefined as any, belowZeroResponseTimeAction),
@@ -260,6 +264,7 @@ describe('Provider stats tests', () => {
           providerStats: nonZeroMockProviderStatsState,
           workers: {},
         },
+        0,
       );
       expect(() =>
         providerStatsReducer(undefined as any, nonZeroResponseTimeAction),

--- a/src/ducks/providerBalancer/workers/workers.spec.ts
+++ b/src/ducks/providerBalancer/workers/workers.spec.ts
@@ -110,11 +110,14 @@ describe('Worker tests', () => {
           currentPayload: null,
         },
       };
-      const action = balancerActions.balancerNetworkSwitchSucceeded({
-        network: 'ETC',
-        providerStats: {},
-        workers,
-      });
+      const action = balancerActions.balancerNetworkSwitchSucceeded(
+        {
+          network: 'ETC',
+          providerStats: {},
+          workers,
+        },
+        0,
+      );
       const selector = selectors.getWorkers;
       states.networkSwitchSucceeded = workerReducer(
         states.workerProcessing,
@@ -137,11 +140,14 @@ describe('Worker tests', () => {
           currentPayload: null,
         },
       };
-      const noTaskAction = balancerActions.balancerNetworkSwitchSucceeded({
-        network: 'ETC',
-        providerStats: {},
-        workers: noTaskWorkers,
-      });
+      const noTaskAction = balancerActions.balancerNetworkSwitchSucceeded(
+        {
+          network: 'ETC',
+          providerStats: {},
+          workers: noTaskWorkers,
+        },
+        0,
+      );
 
       expect(() => workerReducer(undefined as any, noTaskAction)).toThrow(
         'Worker worker2 has no saga task assigned',
@@ -161,11 +167,14 @@ describe('Worker tests', () => {
         },
       };
 
-      const payloadAction = balancerActions.balancerNetworkSwitchSucceeded({
-        network: 'ETC',
-        providerStats: {},
-        workers: payloadWorkers,
-      });
+      const payloadAction = balancerActions.balancerNetworkSwitchSucceeded(
+        {
+          network: 'ETC',
+          providerStats: {},
+          workers: payloadWorkers,
+        },
+        0,
+      );
       expect(() => workerReducer(undefined as any, payloadAction)).toThrow(
         'Worker worker1 should not have an existing payload',
       );

--- a/src/ducks/subscribe/utils.ts
+++ b/src/ducks/subscribe/utils.ts
@@ -25,11 +25,19 @@ export const triggerOnMatchingCallId = (
   }
 };
 
-export function waitForNetworkSwitch(dispatch: Dispatch<RootState>) {
+export function waitForNetworkSwitch(
+  dispatch: Dispatch<RootState>,
+  id: number,
+) {
   return new Promise(res =>
     dispatch(
       subscribeToAction({
-        trigger: BALANCER.NETWORK_SWITCH_SUCCEEDED,
+        trigger: (action: AllActions) => {
+          if (action.type === BALANCER.NETWORK_SWITCH_SUCCEEDED) {
+            return action.meta.id === id;
+          }
+          return false;
+        },
         callback: res,
       }),
     ),

--- a/src/providers/providerProxy.ts
+++ b/src/providers/providerProxy.ts
@@ -11,8 +11,11 @@ import { storeManager } from '@src/ducks/store';
 import { subscribeToAction } from '@src/ducks/subscribe';
 import { triggerOnMatchingCallId } from '@src/ducks/subscribe/utils';
 import { AllProviderMethods, IProvider, Reject, Resolve } from '@src/types';
+import { idGeneratorFactory } from '@src/utils/idGenerator';
 import { logger } from '@src/utils/logging';
 import { allRPCMethods } from './constants';
+
+const idGenerator = idGeneratorFactory();
 
 const respondToCallee = (resolve: Resolve, reject: Reject) => (
   action: IProviderCallFailed | IProviderCallSucceeded | IProviderCallFlushed,
@@ -30,15 +33,6 @@ const respondToCallee = (resolve: Resolve, reject: Reject) => (
   }
 };
 
-const generateCallId = (() => {
-  let callId = 0;
-  return () => {
-    const currValue = callId;
-    callId += 1;
-    return currValue;
-  };
-})();
-
 const makeProviderCall = (
   rpcMethod: AllProviderMethods,
   rpcArgs: string[],
@@ -46,7 +40,7 @@ const makeProviderCall = (
   const isManual = getManualMode(storeManager.getStore().getState());
 
   const providerCall: IProviderCall = {
-    callId: generateCallId(),
+    callId: idGenerator(),
     numOfRetries: 0,
     rpcArgs,
     rpcMethod,

--- a/src/saga/watchers/index.ts
+++ b/src/saga/watchers/index.ts
@@ -9,6 +9,8 @@ import { providerRequestWatcher } from './watchProviderCalls';
 import { providerHealthWatcher } from './watchProviderHealth';
 
 export const watchers = [
+  ...watchNetworkSwitches,
+
   ...subscriptionWatcher,
   ...addProviderConfigWatcher,
   ...balancerFlushWatcher,
@@ -16,6 +18,5 @@ export const watchers = [
   ...providerRequestWatcher,
   ...providerHealthWatcher,
   ...balancerHealthWatcher,
-  ...watchNetworkSwitches,
   ...manualModeWatcher,
 ];

--- a/src/saga/watchers/watchNetworkSwitches/index.ts
+++ b/src/saga/watchers/watchNetworkSwitches/index.ts
@@ -4,26 +4,37 @@ import {
   IBalancerInit,
   IBalancerNetworkSwitchRequested,
 } from '@src/ducks/providerBalancer/balancerConfig';
-import { SagaIterator } from 'redux-saga';
-import { call, fork, put, take } from 'redux-saga/effects';
+import { logger } from '@src/utils/logging';
+import { buffers, SagaIterator } from 'redux-saga';
+import { actionChannel, call, fork, put, take } from 'redux-saga/effects';
 import { initializeNewNetworkProviders } from './helpers';
 
-function* handleNetworkSwitch(): SagaIterator {
-  while (true) {
-    const {
-      payload,
-    }: IBalancerNetworkSwitchRequested | IBalancerInit = yield take([
-      BALANCER.NETWORK_SWTICH_REQUESTED,
-      BALANCER.INIT,
-    ]);
+function* handleNetworkSwitch({
+  payload,
+  meta,
+}: IBalancerNetworkSwitchRequested | IBalancerInit): SagaIterator {
+  const networkSwitchPayload = yield call(
+    initializeNewNetworkProviders,
+    payload.network,
+  );
+  logger.log(`Network switch to ${payload.network} succeeded`);
 
-    const networkSwitchPayload = yield call(
-      initializeNewNetworkProviders,
-      payload.network,
+  yield put(balancerNetworkSwitchSucceeded(networkSwitchPayload, meta.id));
+}
+
+function* networkSwitchActionChannel() {
+  const chan = yield actionChannel(
+    [BALANCER.NETWORK_SWTICH_REQUESTED, BALANCER.INIT],
+    buffers.expanding(50),
+  );
+  while (true) {
+    const action: IBalancerNetworkSwitchRequested | IBalancerInit = yield take(
+      chan,
     );
-    yield put(balancerNetworkSwitchSucceeded(networkSwitchPayload));
+    logger.log(`Taking action ${JSON.stringify(action, null, 1)}`);
+    yield call(handleNetworkSwitch, action);
   }
 }
 
 // we dont use takeevery here to avoid processing two switch requests at the same time
-export const watchNetworkSwitches = [fork(handleNetworkSwitch)];
+export const watchNetworkSwitches = [fork(networkSwitchActionChannel)];

--- a/src/utils/idGenerator.spec.ts
+++ b/src/utils/idGenerator.spec.ts
@@ -1,0 +1,12 @@
+import { idGeneratorFactory } from './idGenerator';
+describe('id generator tests', () => {
+  it('should create two different, independent id generators', () => {
+    const gen1 = idGeneratorFactory();
+    const gen2 = idGeneratorFactory();
+    expect(gen1()).toEqual(0);
+    expect(gen2()).toEqual(0);
+    expect(gen1()).toEqual(1);
+    expect(gen1()).toEqual(2);
+    expect(gen2()).toEqual(1);
+  });
+});

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -1,0 +1,8 @@
+export const idGeneratorFactory = () => {
+  let callId = 0;
+  return () => {
+    const currValue = callId;
+    callId += 1;
+    return currValue;
+  };
+};


### PR DESCRIPTION
Closes https://github.com/MyCryptoHQ/MyCrypto/issues/1601

### Description

Changes the `take` to `actionChannel` for the network switch handler. This buffers the actions instead of dropping incoming ones so they process in a serial manner. Also introduces unique id's for network switches, so for each network switch they'll resolve properly if multiple swtiches are sent at the same time.

### Changes

* Buffer network switches
* Make network switches have unique id


### Steps to Test

`npm run test --- raceconditions` -> 'should buffer network requests and process them one at a time' test is what covers this


