### PR TITLE
Add signmessages to the list of calls that should instantly fail

### DIFF
--- a/__test__/apiTests/web3.spec.ts
+++ b/__test__/apiTests/web3.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@test/utils';
 
 describe('web3 tests', () => {
-  it('should instantly fail a web3 sendTransaction if it fails', async () => {
+  it('should instantly fail a web3 sendTransaction and signMessage if it fails', async () => {
     const { shepherd, redux } = getAPI();
     const node = await shepherd.init({
       customProviders: { MockProvider: MockProviderImplem },
@@ -32,11 +32,18 @@ describe('web3 tests', () => {
 
     /* tslint:disable */
     await node.sendTransaction({} as any).catch(() => {});
+    await node.signMessage({} as any, '').catch(() => {});
     /* tslint:enable */
-    const call = getProviderCallById(redux.store.getState(), 0);
+    const signTxCall = getProviderCallById(redux.store.getState(), 0);
 
-    expect(call.pending).toEqual(false);
-    expect(call.error).toBeTruthy();
-    expect(call.numOfRetries).toEqual(0);
+    expect(signTxCall.pending).toEqual(false);
+    expect(signTxCall.error).toBeTruthy();
+    expect(signTxCall.numOfRetries).toEqual(0);
+
+    const signMsgCall = getProviderCallById(redux.store.getState(), 1);
+
+    expect(signMsgCall.pending).toEqual(false);
+    expect(signMsgCall.error).toBeTruthy();
+    expect(signMsgCall.numOfRetries).toEqual(0);
   });
 });

--- a/__test__/mockNode.ts
+++ b/__test__/mockNode.ts
@@ -73,6 +73,9 @@ export class MockProvider {
   public sendTransaction() {
     return true;
   }
+  public signMessage() {
+    return true;
+  }
   public sendRawTx() {
     return true;
   }

--- a/src/saga/workers/helpers.ts
+++ b/src/saga/workers/helpers.ts
@@ -81,7 +81,8 @@ function* processRequest(providerId: string, workerId: string) {
     });
     return yield put(action);
   } else {
-    const isWeb3SendTx = rpcMethod === 'sendTransaction';
+    const isWeb3SendTx =
+      rpcMethod === 'sendTransaction' || rpcMethod === 'signMessage';
     const actionParams = {
       providerCall: callWithPid,
       error,


### PR DESCRIPTION
Similar to #51, this instantly fails web3 calls and does not retry them, so that users using metamask won't get the same confirmation prompt they just rejected.