### PR TITLE
Wait for web3 methods

### DIFF
--- a/__test__/apiTests/web3.spec.ts
+++ b/__test__/apiTests/web3.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@test/utils';
 
 describe('web3 tests', () => {
-  it('should instantly fail a web3 sendTransaction if it fails', async () => {
+  it('should instantly fail a web3 sendTransaction and signMessage if it fails', async () => {
     const { shepherd, redux } = getAPI();
     const node = await shepherd.init({
       customProviders: { MockProvider: MockProviderImplem },
@@ -32,11 +32,18 @@ describe('web3 tests', () => {
 
     /* tslint:disable */
     await node.sendTransaction({} as any).catch(() => {});
+    await node.signMessage({} as any, '').catch(() => {});
     /* tslint:enable */
-    const call = getProviderCallById(redux.store.getState(), 0);
+    const signTxCall = getProviderCallById(redux.store.getState(), 0);
 
-    expect(call.pending).toEqual(false);
-    expect(call.error).toBeTruthy();
-    expect(call.numOfRetries).toEqual(0);
+    expect(signTxCall.pending).toEqual(false);
+    expect(signTxCall.error).toBeTruthy();
+    expect(signTxCall.numOfRetries).toEqual(0);
+
+    const signMsgCall = getProviderCallById(redux.store.getState(), 1);
+
+    expect(signMsgCall.pending).toEqual(false);
+    expect(signMsgCall.error).toBeTruthy();
+    expect(signMsgCall.numOfRetries).toEqual(0);
   });
 });

--- a/__test__/apiTests/web3.spec.ts
+++ b/__test__/apiTests/web3.spec.ts
@@ -46,4 +46,65 @@ describe('web3 tests', () => {
     expect(signMsgCall.error).toBeTruthy();
     expect(signMsgCall.numOfRetries).toEqual(0);
   });
+
+  it.only(
+    'should wait for longer than configured timeout for web3 methods (5 minutes) to allow for user interaction (like metamask tx confirmation)',
+    async () => {
+      const { shepherd, redux } = getAPI();
+      const node = await shepherd.init({
+        customProviders: { MockProvider: MockProviderImplem },
+        providerCallRetryThreshold: 1,
+      });
+
+      const providerArgs = [
+        new MockProvider(),
+        createMockProxyHandler({
+          baseDelay: 3000,
+          failureRate: 0,
+          getCurrentBlockDelay: 500,
+        }),
+      ];
+
+      shepherd.useProvider(
+        'MockProvider',
+        'eth1',
+        makeMockProviderConfig({
+          concurrency: 4,
+          network: 'ETH',
+          requestFailureThreshold: 2,
+          timeoutThresholdMs: 1000,
+        }),
+        ...providerArgs,
+      );
+
+      await Promise.all([
+        node.sendTransaction({} as any),
+        node.signMessage({} as any, ''),
+      ]);
+
+      const signTxCall = getProviderCallById(redux.store.getState(), 0);
+
+      expect(signTxCall.pending).toEqual(false);
+      expect(signTxCall.error).toBeFalsy();
+      console.log(signTxCall);
+      expect(signTxCall.numOfRetries).toEqual(0);
+
+      const signMsgCall = getProviderCallById(redux.store.getState(), 1);
+
+      expect(signMsgCall.pending).toEqual(false);
+      expect(signMsgCall.error).toBeFalsy();
+      expect(signMsgCall.numOfRetries).toEqual(0);
+
+      try {
+        await node.getBalance('0x');
+      } catch {
+        const getBalanceCall = getProviderCallById(redux.store.getState(), 2);
+
+        expect(getBalanceCall.pending).toEqual(false);
+        expect(getBalanceCall.error).toBeTruthy();
+        expect(getBalanceCall.numOfRetries).toEqual(1);
+      }
+    },
+    70000,
+  );
 });

--- a/__test__/mockNode.ts
+++ b/__test__/mockNode.ts
@@ -73,6 +73,9 @@ export class MockProvider {
   public sendTransaction() {
     return true;
   }
+  public signMessage() {
+    return true;
+  }
   public sendRawTx() {
     return true;
   }

--- a/src/saga/workers/helpers.ts
+++ b/src/saga/workers/helpers.ts
@@ -81,7 +81,8 @@ function* processRequest(providerId: string, workerId: string) {
     });
     return yield put(action);
   } else {
-    const isWeb3SendTx = rpcMethod === 'sendTransaction';
+    const isWeb3SendTx =
+      rpcMethod === 'sendTransaction' || rpcMethod === 'signMessage';
     const actionParams = {
       providerCall: callWithPid,
       error,


### PR DESCRIPTION
Depends on #58

Adds a timeout override for web3 methods, so that users waiting on the confirmation modal dont have their call flushed in an unreasonable amount of time. Patch fix until #33 is fixed