### PR TITLE
Add ability to set queueTimeout on balancer initialization

### DIFF
--- a/__test__/apiTests/initialization.spec.ts
+++ b/__test__/apiTests/initialization.spec.ts
@@ -91,4 +91,40 @@ describe('initialization tests', () => {
     expect(res).toBeTruthy();
     done();
   });
+
+  it(
+    'should properly set default queueTimeout',
+    async () => {
+      const { shepherd } = getAPI();
+      const node = await shepherd.init({
+        customProviders: { MockProvider: MockProviderImplem },
+      });
+
+      try {
+        await node.getBalance('0x');
+      } catch (e) {
+        expect((e as Error).message).toEqual('Call Flushed');
+      }
+    },
+    6000,
+  );
+
+  it(
+    'should allow a custom queueTimeout',
+    async () => {
+      const { shepherd } = getAPI();
+
+      const node = await shepherd.init({
+        customProviders: { MockProvider: MockProviderImplem },
+        queueTimeout: 1000,
+      });
+
+      try {
+        await node.getBalance('0x');
+      } catch (e) {
+        expect((e as Error).message).toEqual('Call Flushed');
+      }
+    },
+    1750,
+  );
 });

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ Enables logging for the library
 | network                 | `string`     | The associated network name of this provider config to be used by the balancer when switching networks                                                                                                                                                                                                                   |
 | storeRoot               | `string`     | The root the shepherd rootReducer when using a custom store. E.g If the top level is { foo, shepherdReducer } then `storeRoot` would be `shepherdReducer`. Note that this setting only supports one level of nesting                                                                                                     |
 | store                   | `Store<any>` | The custom store to use if you want to use your own, make sure to supply the setting above too or else it will not work.                                                                                                                                                                                                 |
+| queueTimeout            | `number`     | Timeout based on when there are pending calls that have not been assigned to a worker. The most common case of this happening is when the balancer is offline and there's calls to the balancer still happening.                                                                                                         |
 
 # FAQ
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,8 @@ class Shepherd implements IShepherd {
    * will initialize to, defaulting to 'ETH'. The {storeRoot} is the shepherd rootReducer when using a custom store.
    * E.g If the top level is { foo, shepherdReducer } then `storeRoot` would be `shepherdReducer`. Note that this setting only supports one level of nesting.
    * The {store} is the custom store to use if you want to use your own, make sure to supply the setting above too or else it will not work.
+   * {queueTimeout} is the timeout based on when there are pending calls that have not been assigned to a worker. The most common case of this happening
+   * is when the balancer is offline and there's calls to the balancer still happening.
    * @returns {Promise<IProvider>} A provider instances to be used for making rpc calls
    * @memberof Shepherd
    */

--- a/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
+++ b/src/ducks/providerBalancer/balancerConfig/balancerConfig.spec.ts
@@ -28,6 +28,10 @@ describe('Balancer config tests', () => {
       expect(selectors.isSwitchingNetworks(INITIAL_ROOT_STATE)).toEqual(false);
     });
 
+    it('should select the queueTimeout', () => {
+      expect(selectors.getQueueTimeout(INITIAL_ROOT_STATE)).toEqual(5000);
+    });
+
     it('should select the entire inital state', () => {
       expect(selectors.getBalancerConfig(INITIAL_ROOT_STATE)).toEqual({
         manual: false,
@@ -35,6 +39,7 @@ describe('Balancer config tests', () => {
         network: 'ETH',
         providerCallRetryThreshold: 3,
         networkSwitchPending: false,
+        queueTimeout: 5000,
       });
     });
   });

--- a/src/ducks/providerBalancer/balancerConfig/reducer.ts
+++ b/src/ducks/providerBalancer/balancerConfig/reducer.ts
@@ -13,6 +13,7 @@ const INITIAL_STATE: IBalancerConfigState = {
   network: 'ETH',
   providerCallRetryThreshold: 3,
   networkSwitchPending: false,
+  queueTimeout: 5000,
 };
 
 const handleBalancerAuto: Reducer<IBalancerConfigState> = (

--- a/src/ducks/providerBalancer/balancerConfig/selectors.ts
+++ b/src/ducks/providerBalancer/balancerConfig/selectors.ts
@@ -5,6 +5,9 @@ import { RootState } from '@src/types';
 export const getBalancerConfig = (state: RootState) =>
   getProviderBalancer(state).balancerConfig;
 
+export const getQueueTimeout = (state: RootState) =>
+  getBalancerConfig(state).queueTimeout;
+
 export const getManualMode = (state: RootState) =>
   getBalancerConfig(state).manual;
 

--- a/src/ducks/providerBalancer/balancerConfig/types.ts
+++ b/src/ducks/providerBalancer/balancerConfig/types.ts
@@ -19,12 +19,14 @@ export enum BALANCER {
 export type BalancerConfigInitConfig = Partial<{
   providerCallRetryThreshold: number;
   network: string;
+  queueTimeout: number;
 }>;
 
 export interface IBalancerConfigState {
   network: string;
   manual: false | string;
   offline: boolean;
+  queueTimeout: number;
   providerCallRetryThreshold: number;
   networkSwitchPending: boolean;
 }

--- a/src/ducks/providerBalancer/providerBalancer.spec.ts
+++ b/src/ducks/providerBalancer/providerBalancer.spec.ts
@@ -10,6 +10,7 @@ describe('Provider balancer tests', () => {
         offline: true,
         providerCallRetryThreshold: 3,
         networkSwitchPending: false,
+        queueTimeout: 5000,
       },
       providerCalls: {},
       providerStats: {},

--- a/src/ducks/providerBalancer/providerStats/reducer.ts
+++ b/src/ducks/providerBalancer/providerStats/reducer.ts
@@ -157,7 +157,11 @@ const handleProviderRemoved: NReducer<IProviderStatsRemoved> = (
 
 const handleProviderCallTimeout: NReducer<IProviderCallTimeout> = (
   state: IProviderStatsState,
-  { payload: { providerCall: { providerId } } }: IProviderCallTimeout,
+  {
+    payload: {
+      providerCall: { providerId },
+    },
+  }: IProviderCallTimeout,
 ) => {
   // check for existence of provider
   const providerToChange = state[providerId];

--- a/src/ducks/providerBalancer/workers/reducer.ts
+++ b/src/ducks/providerBalancer/workers/reducer.ts
@@ -116,7 +116,9 @@ const handleProviderCallSucceeded: WReducer = (
   state: IWorkerState,
   { payload }: IProviderCallSucceeded,
 ) => {
-  const { providerCall: { callId } } = payload;
+  const {
+    providerCall: { callId },
+  } = payload;
   const worker = Object.entries(state).find(
     ([_, { currentPayload }]) =>
       !!(currentPayload && currentPayload.callId === callId),

--- a/src/ducks/selectors.ts
+++ b/src/ducks/selectors.ts
@@ -25,7 +25,9 @@ export const providerExceedsRequestFailureThreshold = (
   state: RootState,
   { payload }: IProviderCallTimeout,
 ) => {
-  const { providerCall: { providerId } } = payload;
+  const {
+    providerCall: { providerId },
+  } = payload;
   const providerStats = getProviderStatsById(state, providerId);
   const providerConfig = getProviderConfigById(state, providerId);
 

--- a/src/saga/watchers/watchCallTimeouts.ts
+++ b/src/saga/watchers/watchCallTimeouts.ts
@@ -12,7 +12,9 @@ import { createRetryCall } from '@src/saga/sagaUtils';
 import { put, select, takeEvery } from 'redux-saga/effects';
 
 function* handleCallTimeouts(action: IProviderCallTimeout) {
-  const { payload: { error, providerCall } } = action;
+  const {
+    payload: { error, providerCall },
+  } = action;
   const { providerId } = providerCall;
 
   const shouldSetProviderOffline: ReturnType<


### PR DESCRIPTION
Closes #17

### Description

Allows queue timeout to be configurable at balancer instantiation phase.
Defaults to 5000ms

